### PR TITLE
Retry download in case of failure

### DIFF
--- a/op-geth/entrypoint.sh
+++ b/op-geth/entrypoint.sh
@@ -31,9 +31,29 @@ else
   echo "[INFO - entrypoint] $DATA_DIR is empty, initializing geth from preloaded data"
   echo "[INFO - entrypoint] Downloading preloaded data from $PRELOADED_DATA_URL. This can take hours..."
   mkdir -p $DATA_DIR
+
+  # Before starting the download, check if a partial file exists.
+  if [ -f "$PRELOADED_DATA_FILE" ]; then
+    echo "[WARNING - entrypoint] Found a partial preloaded data file. Removing it..."
+    rm -f $PRELOADED_DATA_FILE
+  fi
+
+  # Start the download.
   wget -O $PRELOADED_DATA_FILE https://datadirs.optimism.io$PRELOADED_DATA_FILE
+  if [ $? -ne 0 ]; then
+    echo "[ERROR - entrypoint] Failed to download preloaded data."
+    exit 1
+  fi
+
   echo "[INFO - entrypoint] Decompressing preloaded data. This can take a while..."
   zstd -d --stdout $PRELOADED_DATA_FILE | tar xvf - -C $DATA_DIR
+  if [ $? -ne 0 ]; then
+    echo "[ERROR - entrypoint] Failed to decompress preloaded data."
+    rm -f $PRELOADED_DATA_FILE # Remove the faulty file
+    exit 1
+  fi
+
+  echo "[INFO - entrypoint] Removing preloaded data file. Not needed anymore."
   rm -rf $PRELOADED_DATA_FILE
   EXTRA_FLAGS="--datadir.ancient $DATA_DIR/geth/chaindata/ancient"
 fi


### PR DESCRIPTION
Chain data download or file uncompression can fail. If this happens, the container should be restarted to retry it