### PR TITLE
Add legacy geth syncing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,17 +6,17 @@ services:
       args:
         UPSTREAM_VERSION: v1.101311.0
     volumes:
-      - "data:/data"
+      - data:/data
     restart: unless-stopped
     environment:
       - EXTRA_FLAGS
       - P2P_PORT=33142
       - SYNCMODE=snap
-      - "HISTORICAL_RPC_URL=http://op-l2geth.dappnode:8545"
-      - "SEQUENCER_HTTP_URL=https://mainnet-sequencer.optimism.io/"
-    image: "geth.op-geth.dnp.dappnode.eth:0.1.1"
+      - HISTORICAL_RPC_URL=http://op-l2geth.dappnode:8545
+      - SEQUENCER_HTTP_URL=https://mainnet-sequencer.optimism.io/
+    image: geth.op-geth.dnp.dappnode.eth:0.1.1
     ports:
-      - "33142:33142/tcp"
-      - "33142:33142/udp"
+      - 33142:33142/tcp
+      - 33142:33142/udp
 volumes:
   data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       - EXTRA_FLAGS
       - P2P_PORT=33142
       - SYNCMODE=snap
-      - HISTORICAL_RPC_URL=http://op-l2geth.dappnode:8545
       - SEQUENCER_HTTP_URL=https://mainnet-sequencer.optimism.io/
     image: geth.op-geth.dnp.dappnode.eth:0.1.1
     ports:

--- a/op-geth/entrypoint.sh
+++ b/op-geth/entrypoint.sh
@@ -74,5 +74,5 @@ exec geth --rollup.sequencerhttp $SEQUENCER_HTTP_URL \
   --verbosity 3 \
   --port ${P2P_PORT} \
   --networkid 10 \
-  --op-network=op-mainnet \
+  --op-network op-mainnet \
   ${EXTRA_FLAGS}

--- a/op-geth/entrypoint.sh
+++ b/op-geth/entrypoint.sh
@@ -10,7 +10,8 @@ PRELOADED_DATA_FILE=/mainnet-bedrock.tar.zst
 # TODO: Should we add --http.api and --ws.api flags?
 
 echo "[INFO - entrypoint] Starting Geth"
-exec geth --rollup.sequencerhttp $SEQUENCER_HTTP_URL \
+exec geth --datadir $DATA_DIR \
+  --rollup.sequencerhttp $SEQUENCER_HTTP_URL \
   --rollup.disabletxpoolgossip \
   --ws \
   --ws.port 8546 \
@@ -29,4 +30,5 @@ exec geth --rollup.sequencerhttp $SEQUENCER_HTTP_URL \
   --syncmode=snap \
   --port ${P2P_PORT} \
   --networkid=10 \
-  --op-network=op-mainnet
+  --op-network=op-mainnet \
+  ${EXTRA_FLAGS}

--- a/op-geth/entrypoint.sh
+++ b/op-geth/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-DATA_DIR=/data
+SNAP_DATA_DIR=/data/snap
+ARCHIVAL_DATA_DIR=/data/archive
+
+HISTORICAL_RPC_URL=http://op-l2geth.dappnode:8545
 PRELOADED_DATA_FILE=/mainnet-bedrock.tar.zst
 
 # Configuration defined in https://community.optimism.io/docs/developers/bedrock/node-operator-guide/#configuring-op-geth
@@ -9,9 +12,51 @@ PRELOADED_DATA_FILE=/mainnet-bedrock.tar.zst
 
 # TODO: Should we add --http.api and --ws.api flags?
 
+if [ "$_DAPPNODE_GLOBAL_OP_ENABLE_HISTORICAL_RPC" = "true" ]; then
+
+  if [ -z "$HISTORICAL_RPC_URL" ]; then
+    echo "[ERROR - entrypoint] ENABLE_HISTORICAL_RPC is set to true but HISTORICAL_RPC_URL is not defined"
+    sleep 60
+    exit 1
+  fi
+
+  echo "[INFO - entrypoint] Enabling historical RPC"
+  rm -rf $SNAP_DATA_DIR
+
+  # Before starting the download, check if a partial file exists.
+  if [ -f "$PRELOADED_DATA_FILE" ]; then
+    echo "[WARNING - entrypoint] Found a partial preloaded data file. Removing it..."
+    rm -f $PRELOADED_DATA_FILE
+  fi
+
+  # Start the download.
+  wget -O $PRELOADED_DATA_FILE https://datadirs.optimism.io$PRELOADED_DATA_FILE
+  if [ $? -ne 0 ]; then
+    echo "[ERROR - entrypoint] Failed to download preloaded data."
+    exit 1
+  fi
+
+  echo "[INFO - entrypoint] Decompressing preloaded data. This can take a while..."
+  zstd -d --stdout $PRELOADED_DATA_FILE | tar xvf - -C $ARCHIVAL_DATA_DIR
+  if [ $? -ne 0 ]; then
+    echo "[ERROR - entrypoint] Failed to decompress preloaded data."
+    rm -f $PRELOADED_DATA_FILE # Remove the faulty file
+    exit 1
+  fi
+
+  echo "[INFO - entrypoint] Removing preloaded data file. Not needed anymore."
+  rm -rf $PRELOADED_DATA_FILE
+  EXTRA_FLAGS="--rollup.historicalrpc $HISTORICAL_RPC_URL --gcmode archive --syncmode full --datadir $ARCHIVAL_DATA_DIR"
+  # EXTRA_FLAGS="--datadir.ancient $ARCHIVAL_DATA_DIR/geth/chaindata/ancient"
+
+else
+  echo "[INFO - entrypoint] Historical RPC is disabled"
+  EXTRA_FLAGS="--gcmode full --syncmode snap --datadir $SNAP_DATA_DIR"
+  rm -rf $ARCHIVAL_DATA_DIR
+fi
+
 echo "[INFO - entrypoint] Starting Geth"
-exec geth --datadir $DATA_DIR \
-  --rollup.sequencerhttp $SEQUENCER_HTTP_URL \
+exec geth --rollup.sequencerhttp $SEQUENCER_HTTP_URL \
   --rollup.disabletxpoolgossip \
   --ws \
   --ws.port 8546 \
@@ -27,8 +72,7 @@ exec geth --datadir $DATA_DIR \
   --authrpc.vhosts "*" \
   --authrpc.jwtsecret /config/jwtsecret.hex \
   --verbosity 3 \
-  --syncmode=snap \
   --port ${P2P_PORT} \
-  --networkid=10 \
+  --networkid 10 \
   --op-network=op-mainnet \
   ${EXTRA_FLAGS}


### PR DESCRIPTION
op-geth will now sync in snap dir or legacy dir, depending if legacy l2geth is enabled or not.

if legacy l2geth is installed, op-geth will remove any existing snap datadir & sync in archival (implies downloading bedrock datadir)
if legacy l2geth is not installed, op-geth will remove any existing archival datadir & sync in snap mode